### PR TITLE
Fix version conflicts caused by PR#155

### DIFF
--- a/TibiaApi.MongoDB/TibiaApi.MongoDBRepository.csproj
+++ b/TibiaApi.MongoDB/TibiaApi.MongoDBRepository.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Bson" Version="2.10.4" />
-    <PackageReference Include="MongoDB.Driver.Core" Version="2.10.4" />
+    <PackageReference Include="MongoDB.Bson" Version="2.12.2" />
+    <PackageReference Include="MongoDB.Driver.Core" Version="2.12.2" />
     <PackageReference Include="MongoRepository" Version="1.6.11" />
   </ItemGroup>
 


### PR DESCRIPTION
I encountered a similar dependency hell issue when bumps MongoDB.Driver.Core from 2.10.4 to 2.12.4. [(PR#155)](https://github.com/guigomesa/ScrapyTibiaCSharp/pull/155).
Hope this fix can help you.

Best regards,
sucrose